### PR TITLE
Version 1.1.0 - Add support for floats, error handling and reporting

### DIFF
--- a/ByondTopic/ByondTopic.csproj
+++ b/ByondTopic/ByondTopic.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/ByondTopic/ByondTopic.csproj
+++ b/ByondTopic/ByondTopic.csproj
@@ -12,6 +12,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>BYOND;topic;melonmesa</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.1.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <PackageReleaseNotes>Added support for float responses, improved error handling and response type handling.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ByondTopic/ByondTopic.csproj
+++ b/ByondTopic/ByondTopic.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/bobbahbrown/byondtopic</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bobbahbrown/byondtopic</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>BYOND;topic;melonmesa</PackageTags>
+    <PackageTags>BYOND;topic;melonmesa;space station 13;ss13;tgstation</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.1.0</Version>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>

--- a/ByondTopic/InvalidResponseException.cs
+++ b/ByondTopic/InvalidResponseException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ByondTopic
+{
+    public class InvalidResponseException : Exception
+    {
+        public InvalidResponseException()
+        {
+        }
+
+        public InvalidResponseException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidResponseException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/ByondTopic/Response/FloatQueryResponse.cs
+++ b/ByondTopic/Response/FloatQueryResponse.cs
@@ -2,21 +2,21 @@
 
 namespace ByondTopic.Response
 {
+    /// <summary>
+    /// Contains a float response from a BYOND world topic query
+    /// </summary>
     public class FloatQueryResponse : QueryResponse
     {
         public override ResponseType ResponseType => ResponseType.Float;
+        /// <summary>
+        /// The float value contained in the response
+        /// </summary>
         public float Response { get; }
 
         internal FloatQueryResponse(Stream raw)
         {
-            var binRdr = new BinaryReader(raw);
-            Response = ReverseBytes(binRdr.ReadUInt32());
-        }
-
-        internal static float ReverseBytes(float value)
-        {
-            uint v = (uint)value;
-            return (v & 0xFF) << 24 | (v & 0xFF00) << 8 | (v & 0xFF0000) >> 8 | (v & 0xFF000000) >> 24;
+            using var binRdr = new BinaryReader(raw);
+            Response = binRdr.ReadSingle();
         }
     }
 }

--- a/ByondTopic/Response/FloatQueryResponse.cs
+++ b/ByondTopic/Response/FloatQueryResponse.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+
+namespace ByondTopic.Response
+{
+    public class FloatQueryResponse : QueryResponse
+    {
+        public override ResponseType ResponseType => ResponseType.Float;
+        public float Response { get; }
+
+        internal FloatQueryResponse(Stream raw)
+        {
+            var binRdr = new BinaryReader(raw);
+            Response = ReverseBytes(binRdr.ReadUInt32());
+        }
+
+        internal static float ReverseBytes(float value)
+        {
+            uint v = (uint)value;
+            return (v & 0xFF) << 24 | (v & 0xFF00) << 8 | (v & 0xFF0000) >> 8 | (v & 0xFF000000) >> 24;
+        }
+    }
+}

--- a/ByondTopic/Response/QueryResponse.cs
+++ b/ByondTopic/Response/QueryResponse.cs
@@ -6,8 +6,17 @@ namespace ByondTopic.Response
 {
     public abstract class QueryResponse
     {
+        /// <summary>
+        /// The type of response as determined during the network connection
+        /// </summary>
         public virtual ResponseType ResponseType { get; }
+        /// <summary>
+        /// Attempts to cast this QueryResponse to a TextQueryResponse, returns null if not possible
+        /// </summary>
         public TextQueryResponse AsText => this as TextQueryResponse;
+        /// <summary>
+        /// Attempts to cast this QueryResponse to a FloatQueryResponse, returns null if not possible
+        /// </summary>
         public FloatQueryResponse AsFloat => this as FloatQueryResponse;
     }
 }

--- a/ByondTopic/Response/QueryResponse.cs
+++ b/ByondTopic/Response/QueryResponse.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ByondTopic.Response
+{
+    public abstract class QueryResponse
+    {
+        public virtual ResponseType ResponseType { get; }
+        public TextQueryResponse AsText => this as TextQueryResponse;
+        public FloatQueryResponse AsFloat => this as FloatQueryResponse;
+    }
+}

--- a/ByondTopic/Response/ResponseType.cs
+++ b/ByondTopic/Response/ResponseType.cs
@@ -1,5 +1,10 @@
 ﻿namespace ByondTopic.Response
 {
+    /// <summary>
+    /// Dictates the type of response from a BYOND world topic call,
+    /// will typically only be a float or a textual ASCII response.
+    /// Determined from first bytes in the response packet.
+    /// </summary>
     public enum ResponseType
     {
         Unknown,

--- a/ByondTopic/Response/ResponseType.cs
+++ b/ByondTopic/Response/ResponseType.cs
@@ -1,0 +1,9 @@
+﻿namespace ByondTopic.Response
+{
+    public enum ResponseType
+    {
+        Unknown,
+        Float,
+        ASCII
+    }
+}

--- a/ByondTopic/Response/TextQueryResponse.cs
+++ b/ByondTopic/Response/TextQueryResponse.cs
@@ -6,15 +6,24 @@ using System.Web;
 
 namespace ByondTopic.Response
 {
+    /// <summary>
+    /// Contains an ASCII response from a BYOND world topic query
+    /// </summary>
     public class TextQueryResponse : QueryResponse
     {
         public override ResponseType ResponseType => ResponseType.ASCII;
+        /// <summary>
+        /// The text content of the response
+        /// </summary>
         public string Response { get; }
+        /// <summary>
+        /// Attempts to convert the text content to a dictionary
+        /// </summary>
         public Dictionary<string, string> AsDictionary => ConvertToDictionary();
 
         internal TextQueryResponse(Stream raw, int dataLength)
         {
-            var binRdr = new BinaryReader(raw);
+            using var binRdr = new BinaryReader(raw);
             Response = Encoding.ASCII.GetString(binRdr.ReadBytes(dataLength));
         }
 

--- a/ByondTopic/Response/TextQueryResponse.cs
+++ b/ByondTopic/Response/TextQueryResponse.cs
@@ -1,24 +1,27 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Web;
 
-namespace ByondTopic
+namespace ByondTopic.Response
 {
-    public class QueryResponse
+    public class TextQueryResponse : QueryResponse
     {
-        private string Raw { get; }
+        public override ResponseType ResponseType => ResponseType.ASCII;
+        public string Response { get; }
         public Dictionary<string, string> AsDictionary => ConvertToDictionary();
 
-
-        internal QueryResponse(string raw)
+        internal TextQueryResponse(Stream raw, int dataLength)
         {
-            Raw = raw;
+            var binRdr = new BinaryReader(raw);
+            Response = Encoding.ASCII.GetString(binRdr.ReadBytes(dataLength));
         }
 
         private Dictionary<string, string> ConvertToDictionary()
         {
-            var qs = HttpUtility.ParseQueryString(HttpUtility.HtmlDecode(Raw.Substring(5)));
-            return HttpUtility.ParseQueryString(Raw)
+            var qs = HttpUtility.ParseQueryString(Response);
+            return qs
                 .AllKeys
                 .Aggregate(new Dictionary<string, string>(), (Dictionary<string, string> seed, string key) =>
                 {
@@ -33,7 +36,7 @@ namespace ByondTopic
 
         public override string ToString()
         {
-            return Raw;
+            return Response;
         }
     }
 }

--- a/ByondTopic/TopicSource.cs
+++ b/ByondTopic/TopicSource.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using ByondTopic.Response;
+using System.IO;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
@@ -41,13 +42,36 @@ namespace ByondTopic
             NetworkStream stream = client.GetStream();
             stream.Write(memStream.GetBuffer(), 0, (int)binWtr.BaseStream.Length);
 
-            // Get response
-            var response = new byte[4096];
-            var bytesRead = stream.Read(response, 0, response.Length);
-            var responseData = Encoding.ASCII.GetString(response, 5, bytesRead - 6);
+            // Validate response
+            var binRdr = new BinaryReader(stream);
+            if (binRdr.BaseStream.Length < 2)
+            {
+                throw new InvalidResponseException($"Invalid response, returned too few bytes ({binRdr.BaseStream.Length})");
+            }
+            else if (binRdr.ReadByte() != 0x00 || binRdr.ReadByte() != 0x83) // invalid format
+            {
+                throw new InvalidResponseException("Invalid response, cannot determine response type from first two bytes.");
+            }
+
+            // Determine response size
+            ushort responseSize = ReverseBytes(binRdr.ReadUInt16());
+
+            // Determine response type
+            ResponseType responseType = ResponseType.Unknown;
+            switch (binRdr.ReadByte())
+            {
+                case 0x2a:
+                    responseType = ResponseType.Float;
+                    break;
+                case 0x06:
+                    responseType = ResponseType.ASCII;
+                    break;
+            }
 
             // Create response object
-            return new QueryResponse(responseData);
+            return responseType == ResponseType.Float 
+                ? (QueryResponse)new FloatQueryResponse(stream) 
+                : new TextQueryResponse(stream, responseSize);
         }
 
         /// <summary>
@@ -62,8 +86,14 @@ namespace ByondTopic
         /// <returns>The deserialized JSON's object</returns>
         public T QueryJson<T>(string command, bool propertyNameCaseInsensitive = true)
         {
-            var data = Query(command).ToString();
-            return JsonSerializer.Deserialize<T>(data, new JsonSerializerOptions()
+            // Verify that data is textual
+            var data = Query(command);
+            if (data.ResponseType != ResponseType.ASCII)
+            {
+                throw new InvalidResponseException($"Cannot convert non-ASCII response to JSON. (Response type: {data.ResponseType})");
+            }
+
+            return JsonSerializer.Deserialize<T>(data.AsText.ToString(), new JsonSerializerOptions()
             {
                 PropertyNameCaseInsensitive = propertyNameCaseInsensitive
             });
@@ -77,7 +107,7 @@ namespace ByondTopic
         /// </remarks>
         /// <param name="value">The value to reverse the bytes of</param>
         /// <returns>The value with bytes reversed</returns>
-        private static ushort ReverseBytes(ushort value)
+        internal static ushort ReverseBytes(ushort value)
         {
             return (ushort)((value & 0xFFU) << 8 | (value & 0xFF00U) >> 8);
         }

--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@ You can install the package from [Nuget](https://www.nuget.org/packages/ByondTop
 
 ## Usage
 
-The API is designed to be very simple to use, and can be consumed in one of the two following ways. Note that the object returned from the ``Query`` method is a ``QueryResponse`` object, which has a ToString override for the raw text value, as well as a utility method for attempting to convert it into a key,value dictionary.
+The API is designed to be very simple to use, and can be consumed in one of the two following ways. Note that the object returned from the ``Query`` method is a ``QueryResponse`` object, which could contain be a textual ``TextQueryResponse``, or a float ``FloatQueryResponse``.
 
 ```csharp
 using ByondTopic;
 < ... >
 var topic = new TopicSource("bagil.tgstation13.org", 2337);
 var queryResponse = topic.Query("status");
-var keyValueDictionary = queryResponse.AsDictionary;
+var keyValueDictionary = queryResponse.AsText.AsDictionary;
+
+// If we called AsText here, this would throw a null exception as the response
+// of AsText would be null.
+var queryResponseFloat = topic.Query("playing");
+var floatValue = queryResponseFloat.AsFloat.Response;
 ```
 
 Or
@@ -27,4 +32,6 @@ var topic = new TopicSource("byond.paradisestation.org", 6666);
 var queryResponse = topic.QueryJson<Dictionary<string, Dictionary<string, string>>>("manifest");
 ```
 
-Note that the QueryJson method is just a convenient wrapper for deserializing returned JSON using System.Text.Json.
+Note that the ``QueryJson`` method is just a convenient wrapper for deserializing returned JSON using ``System.Text.Json``. Also note that it will throw an exception if the response to the wrapped Query is not a ``TextQueryResponse``.
+
+If given an invalid command, response, or server, the package will typically throw a ``InvalidResponseException`` which can be anticipated and consumed for error handling.


### PR DESCRIPTION
Changelog:
 - Sub-classed out ``QueryResponse``, it will now return a ``TextQueryResponse`` or a ``FloatQueryResponse`` which can be consumed with their respective ``Response`` field when cast.
- Added exceptions for when the server sends no response, or when the server sends an invalid response.
- Improved consistent use of disposable objects

Fixes #1 